### PR TITLE
feat: Update favicon URL in index.html; vscode extension setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
     "**/docs": true
   },
   "jest.jestCommandLine": "__tests__",
-  "jest.rootPath": "__tests__"
+  "jest.rootPath": "__tests__",
+  "cSpell.words": [
+    "pointerupoutside"
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -3,11 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link
-            rel="icon"
-            type="image/x-icon"
-            href="resources/assets/favicon.ico"
-        />
+        <link rel="icon" type="image/x-icon" href="favicon.ico" />
         <title>Windows Squawk</title>
 
         <!-- CSS Files -->


### PR DESCRIPTION
Update the URL for the favicon in the index.html file to ensure it is
linked correctly. The new URL points to the favicon.ico file in the root
directory, which ties in with the web server unlike the previous path. Added word exclusion to cspell vscode addon.